### PR TITLE
TutorialOdoo/Chapter4_Security-ABriefIntroduction

### DIFF
--- a/addons/tutorial/__manifest__.py
+++ b/addons/tutorial/__manifest__.py
@@ -10,6 +10,7 @@
     'images': ['static/description/icon.png'],
     # data files always loaded at installation
     'data': [
+        'security/ir.model.access.csv',
         # 'views/mymodule_view.xml',
     ],
     # data files containing optionally loaded demonstration data

--- a/addons/tutorial/security/ir.model.access.csv
+++ b/addons/tutorial/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+
+tutorial.access_estate_property,access_estate_property,tutorial.model_estate_property,base.group_user,1,1,1,1


### PR DESCRIPTION
**Chapter 4: Security - A Brief Introduction**

In the [previous chapter](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/03_basicmodel.html), we created our first table intended to store business data. In a business application such as Odoo, one of the first questions to consider is who[1](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/04_securityintro.html#who) can access the data. Odoo provides a security mechanism to allow access to the data for specific groups of users.

The topic of security is covered in more detail in [Restrict access to data](https://www.odoo.com/documentation/17.0/developer/tutorials/restrict_data_access.html). This chapter aims to cover the minimum required for our new module.

**Access Rights**

Reference: the documentation related to this topic can be found in [Access Rights](https://www.odoo.com/documentation/17.0/developer/reference/backend/security.html#reference-security-acl).

 **Note Goal: at the end of this section, the following warning should not appear anymore:**

WARNING rd-demo odoo.modules.loading: The models ['estate.property'] have no access rules...
When no access rights are defined on a model, Odoo determines that no users can access the data. It is even notified in the log:

WARNING rd-demo odoo.modules.loading: The models ['estate.property'] have no access rules in module estate, consider adding some, like:
id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
Access rights are defined as records of the model ir.model.access. Each access right is associated with a model, a group (or no group for global access) and a set of permissions: create, read, write and unlink[2](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/04_securityintro.html#unlink). Such access rights are usually defined in a CSV file named ir.model.access.csv.

Here is an example for our previous test_model:

id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
access_test_model,access_test_model,model_test_model,base.group_user,1,0,0,0
id is an [external identifier](https://www.odoo.com/documentation/17.0/developer/glossary.html#term-external-identifier).

name is the name of the ir.model.access.

model_id/id refers to the model which the access right applies to. The standard way to refer to the model is model_<model_name>, where <model_name> is the _name of the model with the . replaced by _. Seems cumbersome? Indeed it is…

group_id/id refers to the group which the access right applies to.

perm_read,perm_write,perm_create,perm_unlink: read, write, create and unlink permissions

 **Exercise**

Add access rights.
Create the ir.model.access.csv file in the appropriate folder and define it in the __manifest__.py file.
Give the read, write, create and unlink permissions to the group base.group_user.
Tip: the warning message in the log gives you most of the solution ;-)