### PR TITLE
TutorialOdoo/Chapter5FinallySomeUIToPlayWith

### DIFF
--- a/addons/tutorial/__manifest__.py
+++ b/addons/tutorial/__manifest__.py
@@ -11,6 +11,8 @@
     # data files always loaded at installation
     'data': [
         'security/ir.model.access.csv',
+        'views/estate_property.xml',
+        'views/menu.xml',
         # 'views/mymodule_view.xml',
     ],
     # data files containing optionally loaded demonstration data

--- a/addons/tutorial/models/estate_property.py
+++ b/addons/tutorial/models/estate_property.py
@@ -1,16 +1,34 @@
 from odoo import fields, models
+from datetime import datetime, timedelta
 
 class EstateProperty(models.Model):
     _name = "estate.property"
     _description = "Real Estate Property"
 
-    name = fields.Char(string="Name", required=True)
+    name = fields.Char(
+        string="Name",
+        required=True
+    )
     description = fields.Text(string="Description")
     postcode = fields.Char(string="Postcode")
-    date_availability = fields.Date(string="Date Availability")
-    expected_price = fields.Float(string="Expected Price", required=True)
-    selling_price = fields.Float(string="Selling Price")
-    bedrooms = fields.Integer(string="Bedrooms")
+    date_availability = fields.Date(
+        string="Date Availability",
+        copy=False,
+        default=lambda self: datetime.today() + timedelta(days=90)
+    )
+    expected_price = fields.Float(
+        string="Expected Price",
+        required=True
+    )
+    selling_price = fields.Float(
+        string="Selling Price",
+        readonly=True,
+        copy=False
+    )
+    bedrooms = fields.Integer(
+        string="Bedrooms",
+        default=2
+    )
     living_area = fields.Integer(string="Living Area")
     facades = fields.Integer(string="Facades")
     garage = fields.Boolean(string="Garage")
@@ -22,3 +40,11 @@ class EstateProperty(models.Model):
         ('east', 'East'),
         ('west', 'West')
     ], string="Garden Orientation")
+    active = fields.Boolean(string="Active")
+    state = fields.Selection([
+        ('new', 'New'),
+        ('offer_received', 'Offer Received'),
+        ('offer_accepted', 'Offer Accepted'),
+        ('sold', 'Sold'),
+        ('canceled', 'Canceled')
+    ], string="Status", required=True, default='new', copy=False)

--- a/addons/tutorial/views/estate_property.xml
+++ b/addons/tutorial/views/estate_property.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <data>
+        <record id="estate_property_menu_action" model="ir.actions.act_window">
+            <field name="name">Properties</field>
+            <field name="res_model">estate.property</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/tutorial/views/menu.xml
+++ b/addons/tutorial/views/menu.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <data>
+        <menuitem id="tutorial_odoo_root" name="Real  Estate">
+            <menuitem id="estate_property_menu_root" name="Advertisements" sequence="10">
+                <!-- Call action Api -->
+                <menuitem
+                    id="estate_property_id_menu_action"
+                    action="estate_property_menu_action"
+                    sequence="10"
+                />
+            </menuitem>
+        </menuitem>
+    </data>
+</odoo>


### PR DESCRIPTION
**Chapter 5: Finally, Some UI To Play With**

Now that we’ve created our new [model](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/03_basicmodel.html) and its corresponding [access rights](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/04_securityintro.html), it is time to interact with the user interface.

At the end of this chapter, we will have created a couple of menus in order to access a default list and form view.

**Exercise**

Add an action.
Create the estate_property_views.xml file in the appropriate folder and define it in the __manifest__.py file.
Create an action for the model estate.property.


**Fields, Attributes And View**


class odoo.fields.Field[[source]](https://github.com/odoo/odoo/blob/17.0/odoo/fields.py#L135)
The field descriptor contains the field definition, and manages accesses and assignments of the corresponding field on records. The following attributes may be provided when instantiating a field:

Parameters
string ([str](https://docs.python.org/3/library/stdtypes.html#str)) – the label of the field seen by users; if not set, the ORM takes the field name in the class (capitalized).

help ([str](https://docs.python.org/3/library/stdtypes.html#str)) – the tooltip of the field seen by users

readonly ([bool](https://docs.python.org/3/library/functions.html#bool)) –

whether the field is readonly (default: False)

This only has an impact on the UI. Any field assignation in code will work (if the field is a stored field or an inversable one).

required ([bool](https://docs.python.org/3/library/functions.html#bool)) – whether the value of the field is required (default: False)

index ([str](https://docs.python.org/3/library/stdtypes.html#str)) –

whether the field is indexed in database, and the kind of index. Note: this has no effect on non-stored and virtual fields. The possible values are:

"btree" or True: standard index, good for many2one

"btree_not_null": BTREE index without NULL values (useful when most
values are NULL, or when NULL is never searched for)

"trigram": Generalized Inverted Index (GIN) with trigrams (good for full-text search)

None or False: no index (default)

default (value or callable) – the default value for the field; this is either a static value, or a function taking a recordset and returning a value; use default=None to discard default values for the field

groups ([str](https://docs.python.org/3/library/stdtypes.html#str)) – comma-separated list of group xml ids (string); this restricts the field access to the users of the given groups only

company_dependent ([bool](https://docs.python.org/3/library/functions.html#bool)) –

whether the field value is dependent of the current company;

The value isn’t stored on the model table. It is registered as ir.property. When the value of the company_dependent field is needed, an ir.property is searched, linked to the current company (and current record if one property exists).

If the value is changed on the record, it either modifies the existing property for the current record (if one exists), or creates a new one for the current company and res_id.

If the value is changed on the company side, it will impact all records on which the value hasn’t been changed.

copy ([bool](https://docs.python.org/3/library/functions.html#bool)) – whether the field value should be copied when the record is duplicated (default: True for normal fields, False for one2many and computed fields, including property fields and related fields)

store ([bool](https://docs.python.org/3/library/functions.html#bool)) – whether the field is stored in database (default:True, False for computed fields)

group_operator ([str](https://docs.python.org/3/library/stdtypes.html#str)) –

aggregate function used by [read_group()](https://www.odoo.com/documentation/17.0/developer/reference/backend/orm.html#odoo.models.Model.read_group) when grouping on this field.

Supported aggregate functions are:

array_agg : values, including nulls, concatenated into an array

count : number of rows

count_distinct : number of distinct rows

bool_and : true if all values are true, otherwise false

bool_or : true if at least one value is true, otherwise false

max : maximum value of all values

min : minimum value of all values

avg : the average (arithmetic mean) of all values

sum : sum of all values

group_expand ([str](https://docs.python.org/3/library/stdtypes.html#str)) –

function used to expand read_group results when grouping on the current field.

@api.model
def _read_group_selection_field(self, values, domain, order):
    return ['choice1', 'choice2', ...] # available selection choices.

@api.model
def _read_group_many2one_field(self, records, domain, order):
    return records + self.search([custom_domain])