### PR TITLE
TutorialOdoo/Chapter6_BasicViews

### DIFF
--- a/addons/tutorial/views/estate_property.xml
+++ b/addons/tutorial/views/estate_property.xml
@@ -1,6 +1,93 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo>
     <data>
+
+        <!-- Search -->
+        <record id="search_estate_property" model="ir.ui.view">
+            <field name="name">estate.property.search</field>
+            <field name="model">estate.property</field>
+            <field name="arch" type="xml">
+                <search string="Tests">
+                    <field name="name" string="Title"/>
+                    <field name="postcode"/>
+                    <field name="expected_price" string="Expected price"/>
+                    <field name="bedrooms"/>
+                    <field name="living_area"/>
+                    <field name="facades"/>
+                    <separator/>
+                    <filter string="Not available" name="active" domain="[ ('active', '=', False)]"/>
+                    <filter string="Available" name="state" domain="[ '|', ('state', '=', 'new'), ('state', '=', 'offer_received') ]"/>
+                    <group expand="1" string="Group By">
+                        <filter string="Postcode" name="postcode" context="{'group_by':'postcode'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <!-- Form -->
+        <record id="form_estate_property" model="ir.ui.view">
+            <field name="name">estate.property.form</field>
+            <field name="model">estate.property</field>
+            <field name="arch" type="xml">
+                <form string="Properties">
+                    <sheet>
+                        <div class="oe_title">
+                            <div class="oe_edit_only">
+                                <label for="name"/>
+                            </div>
+                            <h1 class="mb32">
+                                <field name="name" class="mb16"/>
+                            </h1>
+                            <field name="active" invisible="1"/>
+                        </div>
+                        <group>
+                            <group>
+                                <field name="postcode"/>
+                                <field name="date_availability"/>
+                            </group>
+                            <group>
+                                <field name="expected_price"/>
+                                <field name="selling_price"/>
+                            </group>
+                        </group>
+                        <notebook>
+                            <page string="Description">
+                                <group>
+                                    <field name="description"/>
+                                    <field name="bedrooms"/>
+                                    <field name="living_area"/>
+                                    <field name="facades"/>
+                                    <field name="garage"/>
+                                    <field name="garden"/>
+                                    <field name="garden_area"/>
+                                    <field name="garden_orientation"/>
+                                    <field name="active"/>
+                                </group>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <!-- Tree -->
+        <record id="tree_estate_property" model="ir.ui.view">
+            <field name="name">estate.property.tree</field>
+            <field name="model">estate.property</field>
+            <field name="arch" type="xml">
+                <tree string="Property">
+                    <field name="name" string="Title"/>
+                    <field name="postcode" string="Postcode" />
+                    <field name="bedrooms" string="Bedrooms"/>
+                    <field name="living_area" string="Living Area (sqm)"/>
+                    <field name="expected_price" string="Expected Price"/>
+                    <field name="selling_price" string="Selling Price"/>
+                    <field name="date_availability" string="Available from"/>
+                </tree>
+            </field>
+        </record>
+
+        <!-- Action -->
         <record id="estate_property_menu_action" model="ir.actions.act_window">
             <field name="name">Properties</field>
             <field name="res_model">estate.property</field>


### PR DESCRIPTION
**Chapter 6: Basic Views**

We have seen in the [previous chapter](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/05_firstui.html) that Odoo is able to generate default views for a given model. In practice, the default view is never acceptable for a business application. Instead, we should at least organize the various fields in a logical manner.

Views are defined in XML files with actions and menus. They are instances of the ir.ui.view model.
In our real estate module, we need to organize the fields in a logical way:
in the list (tree) view, we want to display more than just the name.
in the form view, the fields should be grouped.

in the search view, we must be able to search on more than just the name. Specifically, we want a filter for the ‘Available’ properties and a shortcut to group by postcode.