### PR TITLE
TutorialOdoo/Chapter7_RelationsBetweenModels

### DIFF
--- a/addons/tutorial/__manifest__.py
+++ b/addons/tutorial/__manifest__.py
@@ -12,6 +12,9 @@
     'data': [
         'security/ir.model.access.csv',
         'views/estate_property.xml',
+        'views/estate_property_type.xml',
+        'views/estate_property_tag.xml',
+        'views/estate_property_offer.xml',
         'views/menu.xml',
         # 'views/mymodule_view.xml',
     ],

--- a/addons/tutorial/models/__init__.py
+++ b/addons/tutorial/models/__init__.py
@@ -1,1 +1,4 @@
 from . import estate_property
+from . import estate_property_type
+from . import estate_property_tag
+from . import estate_property_offer

--- a/addons/tutorial/models/estate_property.py
+++ b/addons/tutorial/models/estate_property.py
@@ -48,3 +48,27 @@ class EstateProperty(models.Model):
         ('sold', 'Sold'),
         ('canceled', 'Canceled')
     ], string="Status", required=True, default='new', copy=False)
+    property_type_id = fields.Many2one(
+        comodel_name='estate.property.type',
+        string='Property Type',
+    )
+    buyer = fields.Many2one(
+        comodel_name="res.partner",
+        string="Buyer"
+    )
+    salesperson = fields.Many2one(
+        comodel_name='res.users',
+        string='Salesman',
+        required=True,
+        index=True,
+        default=lambda self: self.env.user,
+    )
+    tag_ids = fields.Many2many(
+        comodel_name="estate.property.tag",
+        string="Tags"
+    )
+    offer_ids = fields.One2many(
+        comodel_name='estate.property.offer',
+        inverse_name='property_id',
+        string='Offers'
+    )

--- a/addons/tutorial/models/estate_property_offer.py
+++ b/addons/tutorial/models/estate_property_offer.py
@@ -1,0 +1,27 @@
+from odoo import fields, models
+
+class EstatePropertyOffer(models.Model):
+    _name = "estate.property.offer"
+    _description = "Real Estate Property Offer"
+
+    price = fields.Float(
+        string="Price"
+    )
+    status = fields.Selection(
+        string='Status',
+        selection=[
+            ('accepted', 'Accepted'),
+            ('refused', 'Refused')
+        ],
+        copy=False
+    )
+    partner_id = fields.Many2one(
+        comodel_name='res.partner',
+        string='Partner',
+        required=True
+    )
+    property_id = fields.Many2one(
+        comodel_name='estate.property',
+        string='Property',
+        required=True
+    )

--- a/addons/tutorial/models/estate_property_tag.py
+++ b/addons/tutorial/models/estate_property_tag.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+class EstatePropertyTag(models.Model):
+    _name = "estate.property.tag"
+    _description = "Real Estate Property Tag"
+
+    name = fields.Char(
+        string="Name",
+        required=True
+    )

--- a/addons/tutorial/models/estate_property_type.py
+++ b/addons/tutorial/models/estate_property_type.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+class EstatePropertyType(models.Model):
+    _name = "estate.property.type"
+    _description = "Real Estate Property Type"
+
+    name = fields.Char(
+        string="Name",
+        required=True
+    )

--- a/addons/tutorial/security/ir.model.access.csv
+++ b/addons/tutorial/security/ir.model.access.csv
@@ -1,3 +1,9 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 
 tutorial.access_estate_property,access_estate_property,tutorial.model_estate_property,base.group_user,1,1,1,1
+
+tutorial.access_estate_property_type,access_estate_property_type,tutorial.model_estate_property_type,base.group_user,1,1,1,1
+
+tutorial.access_estate_property_tag,access_estate_property_tag,tutorial.model_estate_property_tag,base.group_user,1,1,1,1
+
+tutorial.access_estate_property_offer,access_estate_property_offer,tutorial.model_estate_property_offer,base.group_user,1,1,1,1

--- a/addons/tutorial/views/estate_property.xml
+++ b/addons/tutorial/views/estate_property.xml
@@ -38,10 +38,17 @@
                             <h1 class="mb32">
                                 <field name="name" class="mb16"/>
                             </h1>
+                            <div class="oe_edit_only">
+                                <label for="tag_ids"/>
+                            </div>
+                            <h3 class="mb32">
+                                <field name="tag_ids" widget="many2many_tags"/>
+                            </h3>
                             <field name="active" invisible="1"/>
                         </div>
                         <group>
                             <group>
+                                <field name="property_type_id"/>
                                 <field name="postcode"/>
                                 <field name="date_availability"/>
                             </group>
@@ -62,6 +69,17 @@
                                     <field name="garden_area"/>
                                     <field name="garden_orientation"/>
                                     <field name="active"/>
+                                </group>
+                            </page>
+                            <page string="Offers">
+                                <group>
+                                    <field name="offer_ids" string=""/>
+                                </group>
+                            </page>
+                            <page string="Other info">
+                                <group>
+                                    <field name="salesperson"/>
+                                    <field name="buyer"/>
                                 </group>
                             </page>
                         </notebook>

--- a/addons/tutorial/views/estate_property_offer.xml
+++ b/addons/tutorial/views/estate_property_offer.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <data>
+
+        <!-- Form -->
+        <record id="form_estate_property_offer" model="ir.ui.view">
+            <field name="name">estate.property.offer.form</field>
+            <field name="model">estate.property.offer</field>
+            <field name="arch" type="xml">
+                <form string="Offers">
+                    <group>
+                        <field name="price" string="Price"/>
+                        <field name="partner_id" string="Partner"/>
+                        <field name="status" string="Status" />
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <!-- Tree -->
+        <record id="tree_estate_property_offer" model="ir.ui.view">
+            <field name="name">estate.property.offer.tree</field>
+            <field name="model">estate.property.offer</field>
+            <field name="arch" type="xml">
+                <tree string="offers">
+                    <field name="price" string="Price"/>
+                    <field name="partner_id" string="Partner"/>
+                    <field name="status" string="Status" />
+                </tree>
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/addons/tutorial/views/estate_property_tag.xml
+++ b/addons/tutorial/views/estate_property_tag.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+
+    <data>
+
+        <!-- Form -->
+        <record id="form_estate_property_tag" model="ir.ui.view">
+            <field name="name">estate.property.tag.form</field>
+            <field name="model">estate.property.tag</field>
+            <field name="arch" type="xml">
+                <form string="Properties">
+                    <sheet>
+                        <div class="oe_title">
+                            <div class="oe_edit_only">
+                                <label for="name"/>
+                            </div>
+                            <h1 class="mb32">
+                                <field name="name" class="mb16"/>
+                            </h1>
+                        </div>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <!-- Action -->
+        <record id="estate_property_tag_menu_action" model="ir.actions.act_window">
+            <field name="name">Property Tags</field>
+            <field name="res_model">estate.property.tag</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+    </data>
+
+</odoo>

--- a/addons/tutorial/views/estate_property_type.xml
+++ b/addons/tutorial/views/estate_property_type.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+
+    <data>
+
+        <!-- Form -->
+        <record id="form_estate_property_type" model="ir.ui.view">
+            <field name="name">estate.property.type.form</field>
+            <field name="model">estate.property.type</field>
+            <field name="arch" type="xml">
+                <form string="Properties">
+                    <sheet>
+                        <div class="oe_title">
+                            <div class="oe_edit_only">
+                                <label for="name"/>
+                            </div>
+                            <h1 class="mb32">
+                                <field name="name" class="mb16"/>
+                            </h1>
+                        </div>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <!-- Action -->
+        <record id="estate_property_type_menu_action" model="ir.actions.act_window">
+            <field name="name">Property type</field>
+            <field name="res_model">estate.property.type</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+    </data>
+
+</odoo>

--- a/addons/tutorial/views/menu.xml
+++ b/addons/tutorial/views/menu.xml
@@ -2,6 +2,7 @@
 <odoo>
     <data>
         <menuitem id="tutorial_odoo_root" name="Real  Estate">
+            <!-- Options Advertisements -->
             <menuitem id="estate_property_menu_root" name="Advertisements" sequence="10">
                 <!-- Call action Api -->
                 <menuitem
@@ -10,6 +11,24 @@
                     sequence="10"
                 />
             </menuitem>
+
+            <!-- Options Settings -->
+            <menuitem id="settings_menu_root" name="Settings" sequence="20">
+                <!-- Call action Api -->
+                <menuitem
+                    id="estate_property_type_id_menu_action"
+                    action="estate_property_type_menu_action"
+                    sequence="10"
+                />
+
+                <menuitem
+                    id="estate_property_tag_id_menu_action"
+                    action="estate_property_tag_menu_action"
+                    sequence="20"
+                />
+            </menuitem>
+
         </menuitem>
+
     </data>
 </odoo>


### PR DESCRIPTION
**Chapter 7: Relations Between Models**

The [previous chapter](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/06_basicviews.html) covered the creation of custom views for a model containing basic fields. However, in any real business scenario we need more than one model. Moreover, links between models are necessary. One can easily imagine one model containing the customers and another one containing the list of users. You might need to refer to a customer or a user on any existing business model.

In our real estate module, we want the following information for a property:
the customer who bought the property
the real estate agent who sold the property
the property type: house, apartment, penthouse, castle…
a list of tags characterizing the property: cozy, renovated…
a list of the offers received

ON THIS PAGE
[Many2one](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/07_relations.html#many2one)
[Many2many](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/07_relations.html#many2many)
[One2many](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/07_relations.html#one2many)