### PR TITLE
TutorialOdoo/Chapter8_ComputedFieldsAndOnchanges

### DIFF
--- a/addons/tutorial/views/estate_property.xml
+++ b/addons/tutorial/views/estate_property.xml
@@ -54,6 +54,7 @@
                             </group>
                             <group>
                                 <field name="expected_price"/>
+                                <field name="best_price"/>
                                 <field name="selling_price"/>
                             </group>
                         </group>
@@ -68,6 +69,7 @@
                                     <field name="garden"/>
                                     <field name="garden_area"/>
                                     <field name="garden_orientation"/>
+                                    <field name="total_area"/>
                                     <field name="active"/>
                                 </group>
                             </page>

--- a/addons/tutorial/views/estate_property_offer.xml
+++ b/addons/tutorial/views/estate_property_offer.xml
@@ -12,6 +12,8 @@
                         <field name="price" string="Price"/>
                         <field name="partner_id" string="Partner"/>
                         <field name="status" string="Status" />
+                        <field name="validity" string="validity" />
+                        <field name="date_deadline" string="Date deadline" />
                     </group>
                 </form>
             </field>
@@ -25,6 +27,8 @@
                 <tree string="offers">
                     <field name="price" string="Price"/>
                     <field name="partner_id" string="Partner"/>
+                    <field name="validity" string="validity"/>
+                    <field name="date_deadline" string="Date deadline"/>
                     <field name="status" string="Status" />
                 </tree>
             </field>


### PR DESCRIPTION
**Chapter 8: Computed Fields And Onchanges**

The [relations between models](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/07_relations.html) are a key component of any Odoo module. They are necessary for the modelization of any business case. However, we may want links between the fields within a given model. Sometimes the value of one field is determined from the values of other fields and other times we want to help the user with data entry.

These cases are supported by the concepts of computed fields and onchanges. Although this chapter is not technically complex, the semantics of both concepts is very important. This is also the first time we will write Python logic. Until now we haven’t written anything other than class definitions and field declarations.

**ON THIS PAGE**

[Computed Fields](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/08_compute_onchange.html#computed-fields)
[Onchanges](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/08_compute_onchange.html#onchanges)
[How to use them?](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/08_compute_onchange.html#how-to-use-them)