### PR TITLE
TutorialOdoo/Chapter9_ReadyForSomeAction

### DIFF
--- a/addons/tutorial/models/estate_property.py
+++ b/addons/tutorial/models/estate_property.py
@@ -1,5 +1,6 @@
 from odoo import fields, models, api
 from datetime import datetime, timedelta
+from odoo.exceptions import UserError
 
 class EstateProperty(models.Model):
     _name = "estate.property"
@@ -110,4 +111,15 @@ class EstateProperty(models.Model):
             else:
                 record.garden_area = False
                 record.garden_orientation = False
+
+    def action_sold_property(self):
+        for record in self:
+            if record.state == "canceled":
+                raise UserError("A canceled property cannot be set as sold.")
+            record.state = "sold"
+    def action_cancel_properety(self):
+        for record in self:
+            if record.state == "sold":
+                raise UserError("A sold property cannot be set as canceled.")
+            record.state = "canceled"
 

--- a/addons/tutorial/views/estate_property.xml
+++ b/addons/tutorial/views/estate_property.xml
@@ -30,6 +30,23 @@
             <field name="model">estate.property</field>
             <field name="arch" type="xml">
                 <form string="Properties">
+                    <header>
+                        <button
+                            name="action_sold_property"
+                            string="Sold"
+                            type="object"
+                            class=""
+                        />
+                        <!-- attrs="{'invisible': ['|','|', ('active','=',False), ('probability', '=', 100), ('type', '=', 'lead')]}" -->
+                        <button
+                            name="action_cancel_properety"
+                            string="Cancel"
+                            type="object"
+                            class=""
+                        />
+                        <!-- context="{'default_lead_id': active_id}"
+                        attrs="{'invisible': ['|', ('type', '=', 'lead'),('active', '=', False),('probability', '&lt;', 100)]}" -->
+                    </header>
                     <sheet>
                         <div class="oe_title">
                             <div class="oe_edit_only">
@@ -38,6 +55,9 @@
                             <h1 class="mb32">
                                 <field name="name" class="mb16"/>
                             </h1>
+                            <group>
+                                <field name="state"/>
+                            </group>
                             <div class="oe_edit_only">
                                 <label for="tag_ids"/>
                             </div>
@@ -102,6 +122,7 @@
                     <field name="living_area" string="Living Area (sqm)"/>
                     <field name="expected_price" string="Expected Price"/>
                     <field name="selling_price" string="Selling Price"/>
+                    <field name="state"/>
                     <field name="date_availability" string="Available from"/>
                 </tree>
             </field>

--- a/addons/tutorial/views/estate_property_offer.xml
+++ b/addons/tutorial/views/estate_property_offer.xml
@@ -29,6 +29,16 @@
                     <field name="partner_id" string="Partner"/>
                     <field name="validity" string="validity"/>
                     <field name="date_deadline" string="Date deadline"/>
+                    <button
+                        name="action_offer_accept"
+                        type="object"
+                        icon="fa-check"
+                    />
+                    <button
+                        name="action_offer_refuse"
+                        type="object"
+                        icon="fa-remove"
+                    />
                     <field name="status" string="Status" />
                 </tree>
             </field>


### PR DESCRIPTION
**Chapter 9: Ready For Some Action?**

So far we have mostly built our module by declaring fields and views. We just introduced business logic in the [previous chapter](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/08_compute_onchange.html) thanks to computed fields and onchanges. In any real business scenario, we would want to link some business logic to action buttons. In our real estate example, we would like to be able to:

cancel or set a property as sold

accept or refuse an offer

One could argue that we can already do these things by changing the state manually, but this is not really convenient. Moreover, we want to add some extra processing: when an offer is accepted we want to set the selling price and the buyer for the property.

**ON THIS PAGE**

[Object Type](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/09_actions.html#object-type)
[Action Type](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/09_actions.html#action-type)