### PR TITLE
TutorialOdoo/Chapter12_Inheritance

### DIFF
--- a/addons/tutorial/__manifest__.py
+++ b/addons/tutorial/__manifest__.py
@@ -15,6 +15,7 @@
         'views/estate_property_offer.xml',
         'views/estate_property_type.xml',
         'views/estate_property_tag.xml',
+        'views/res_users_views.xml',
         'views/menu.xml',
         # 'views/mymodule_view.xml',
     ],

--- a/addons/tutorial/models/__init__.py
+++ b/addons/tutorial/models/__init__.py
@@ -2,3 +2,4 @@ from . import estate_property
 from . import estate_property_type
 from . import estate_property_tag
 from . import estate_property_offer
+from . import inherited_model

--- a/addons/tutorial/models/estate_property.py
+++ b/addons/tutorial/models/estate_property.py
@@ -144,3 +144,9 @@ class EstateProperty(models.Model):
                 raise UserError("A sold property cannot be set as canceled.")
             record.state = "canceled"
 
+    # @api.model
+    def unlink(self):
+        for property_record in self:
+            if property_record.state not in ['new', 'canceled']:
+                raise UserError("You cannot delete a property that is not in 'New' or 'Canceled' state.")
+        return super(EstateProperty, self).unlink()

--- a/addons/tutorial/models/estate_property_offer.py
+++ b/addons/tutorial/models/estate_property_offer.py
@@ -88,3 +88,16 @@ class EstatePropertyOffer(models.Model):
     def action_offer_refuse(self):
         for record in self:
             record.status = "refused"
+
+    @api.model
+    def create(self, vals):
+        if 'property_id' in vals:
+            property_id = vals['property_id']
+            property_obj = self.env['estate.property'].browse(property_id)
+            if 'price' in vals:
+                new_offer_price = vals['price']
+                existing_offers = property_obj.offer_ids.filtered(lambda offer: offer.price > new_offer_price)
+                if existing_offers:
+                    raise UserError("You cannot create an offer with a lower amount than an existing offer.")
+            property_obj.write({'state': 'offer_received'})
+        return super(EstatePropertyOffer, self).create(vals)

--- a/addons/tutorial/models/inherited_model.py
+++ b/addons/tutorial/models/inherited_model.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+class InheritedModel(models.Model):
+    _inherit = "res.users"
+
+    property_ids = fields.One2many(
+        comodel_name="estate.property",
+        inverse_name="salesperson",
+        string="Properties",
+        domain="[('state', '=', 'new')]"
+    )

--- a/addons/tutorial/views/res_users_views.xml
+++ b/addons/tutorial/views/res_users_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_users_form_extension" model="ir.ui.view">
+        <field name="name">view.users.form.extension</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page string="Properties">
+                    <field name="property_ids" readonly="1"/>
+                </page>
+            </notebook>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
**Chapter 12: Inheritance**

A powerful aspect of Odoo is its modularity. A module is dedicated to a business need, but modules can also interact with one another. This is useful for extending the functionality of an existing module. For example, in our real estate scenario we want to display the list of a salesperson’s properties directly in the regular user view.

But before going through the specific Odoo module inheritance, let’s see how we can alter the behavior of the standard CRUD (Create, Retrieve, Update or Delete) methods.

**ON THIS PAGE**

[Python Inheritance](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/12_inheritance.html#python-inheritance)
[Model Inheritance](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/12_inheritance.html#model-inheritance)
[View Inheritance](https://www.odoo.com/documentation/17.0/developer/tutorials/server_framework_101/12_inheritance.html#view-inheritance)