### PR TITLE
TutorialOdooClikerGame/2_CountExternalClicks

### DIFF
--- a/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.js
+++ b/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { registry } from "@web/core/registry"
-import { Component, useState } from "@odoo/owl"
+import { Component, useState, useExternalListener } from "@odoo/owl"
 
 export class ClickerSystray extends Component {
     static template = "awesome_clicker.ClickerSystray"
@@ -9,10 +9,11 @@ export class ClickerSystray extends Component {
 
     setup() {
         this.state = useState({ counter: 0 })
+        useExternalListener(document.body, "click", () => this.state.counter++, true)
     }
 
     increment() {
-        this.state.counter++
+        this.state.counter += 9
     }
 
 }


### PR DESCRIPTION
2. Count external clicks
Well, to be honest, it is not much fun yet. So let us add a new feature: we want all clicks in the user interface to count, so the user is incentivized to use Odoo as much as possible! But obviously, the intentional clicks on the main counter should still count more.

Use useExternalListener to listen on all clicks on document.body.

Each of these clicks should increase the counter value by 1.

Modify the code so that each click on the counter increased the value by 10

Make sure that a click on the counter does not increase the value by 11!

Also additional challenge: make sure the external listener capture the events, so we don’t miss any clicks.