### PR TITLE
TutorialOdooClikerGame/3_CreateAClientAction

### DIFF
--- a/addons/awesome_clicker/static/src/clicker_action/clicker_action.js
+++ b/addons/awesome_clicker/static/src/clicker_action/clicker_action.js
@@ -1,0 +1,11 @@
+/** @odoo-module */
+
+import { Component } from "@odoo/owl"
+import { registry } from "@web/core/registry"
+
+class ClickerClientAction extends Component {
+    static template = "awesome_clicker.ClickerClientAction"
+    static props = ['*']
+}
+
+registry.category("actions").add("awesome_clicker.client_action", ClickerClientAction)

--- a/addons/awesome_clicker/static/src/clicker_action/clicker_action.xml
+++ b/addons/awesome_clicker/static/src/clicker_action/clicker_action.xml
@@ -1,0 +1,7 @@
+<templates xml:space="preserve">
+
+    <t t-name="awesome_clicker.ClickerClientAction">
+        Clicker client action
+    </t>
+
+</templates>

--- a/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.js
+++ b/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.js
@@ -1,7 +1,8 @@
 /** @odoo-module */
 
-import { registry } from "@web/core/registry"
 import { Component, useState, useExternalListener } from "@odoo/owl"
+import { registry } from "@web/core/registry"
+import { useService } from "@web/core/utils/hooks"
 
 export class ClickerSystray extends Component {
     static template = "awesome_clicker.ClickerSystray"
@@ -9,11 +10,21 @@ export class ClickerSystray extends Component {
 
     setup() {
         this.state = useState({ counter: 0 })
+        this.action = useService("action")
         useExternalListener(document.body, "click", () => this.state.counter++, true)
     }
 
     increment() {
         this.state.counter += 9
+    }
+
+    openClientAction() {
+        this.action.doAction({
+            type: "ir.actions.client",
+            tag: "awesome_clicker.client_action",
+            target: "new",
+            name: "Clicker Game, JQS"
+        })
     }
 
 }

--- a/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.xml
+++ b/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.xml
@@ -6,6 +6,9 @@
             <button class="btn btn-secondary" t-on-click="increment">
                 <i class="fa fa-lg fa-plus"></i>
             </button>
+            <button class="btn btn-secondary" t-on-click="openClientAction">
+                Open
+            </button>
         </div>
     </t>
 </templates>


### PR DESCRIPTION
3. Create a client action
Currently, the current user interface is quite small: it is just a systray item. We certainly need more room to display more of our game. To do that, let us create a client action. A client action is a main action, managed by the web client, that displays a component.

Create a client_action.js (and xml) file, with a hello world component.

Register that client action in the action registry under the name awesome_clicker.client_action

Add a button on the systray item with the text Open. Clicking on it should open the client action awesome_clicker.client_action (use the action service to do that).

To avoid disrupting employees’ workflow, we prefer the client action to open within a popover rather than in fullscreen mode. Modify the doAction call to open it in a popover.

 Tip

You can use target: "new" in the doAction to open the action in a popover:

{
   type: "ir.actions.client",
   tag: "awesome_clicker.client_action",
   target: "new",
   name: "Clicker"
}