### PR TITLE
TutorialOdooClikerGame/4_MoveTheStateToAService

### DIFF
--- a/addons/awesome_clicker/static/src/clicker_action/clicker_action.xml
+++ b/addons/awesome_clicker/static/src/clicker_action/clicker_action.xml
@@ -1,7 +1,0 @@
-<templates xml:space="preserve">
-
-    <t t-name="awesome_clicker.ClickerClientAction">
-        Clicker client action
-    </t>
-
-</templates>

--- a/addons/awesome_clicker/static/src/clicker_service.js
+++ b/addons/awesome_clicker/static/src/clicker_service.js
@@ -1,0 +1,23 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry"
+import { reactive } from "@odoo/owl"
+
+const clickerService = {
+    start(env) {
+        const state = reactive({ clicks: 0 })
+
+        function increment(inc) {
+            state.clicks += inc
+        }
+
+        document.addEventListener("click", () => increment(1), true )
+
+        return {
+            state,
+            increment,
+        }
+    },
+}
+
+registry.category("services").add("awesome_clicker.clicker", clickerService)

--- a/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.js
+++ b/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.js
@@ -9,13 +9,9 @@ export class ClickerSystray extends Component {
     static props = {}
 
     setup() {
-        this.state = useState({ counter: 0 })
+        // this.state = useState({ counter: 0 })
         this.action = useService("action")
-        useExternalListener(document.body, "click", () => this.state.counter++, true)
-    }
-
-    increment() {
-        this.state.counter += 9
+        this.clickService = useState(useService("awesome_clicker.clicker"))
     }
 
     openClientAction() {

--- a/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.xml
+++ b/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
     <t t-name="awesome_clicker.ClickerSystray">
         <div class="o_nav_entry">
-            Clicks: <t t-esc="state.counter"/>
-            <button class="btn btn-secondary" t-on-click="increment">
+            Clicks: <t t-esc="clickService.state.clicks"/>
+            <button class="btn btn-secondary" t-on-click="() => this.clickService.increment(9)">
                 <i class="fa fa-lg fa-plus"></i>
             </button>
             <button class="btn btn-secondary" t-on-click="openClientAction">

--- a/addons/awesome_clicker/static/src/client_action/client_action.js
+++ b/addons/awesome_clicker/static/src/client_action/client_action.js
@@ -1,11 +1,17 @@
 /** @odoo-module */
 
-import { Component } from "@odoo/owl"
+import { Component, useState } from "@odoo/owl"
 import { registry } from "@web/core/registry"
+import { useService } from "@web/core/utils/hooks"
 
 class ClickerClientAction extends Component {
     static template = "awesome_clicker.ClickerClientAction"
     static props = ['*']
+
+    setup() {
+        this.clickService = useState(useService("awesome_clicker.clicker"))
+    }
+
 }
 
 registry.category("actions").add("awesome_clicker.client_action", ClickerClientAction)

--- a/addons/awesome_clicker/static/src/client_action/client_action.xml
+++ b/addons/awesome_clicker/static/src/client_action/client_action.xml
@@ -1,0 +1,12 @@
+<templates xml:space="preserve">
+
+    <t t-name="awesome_clicker.ClickerClientAction">
+        <div class="ms-1 mt-1">
+            <span>Clicks: <t t-esc="clickService.state.clicks"/></span>
+            <button class="btn btn-primary ms-1" t-on-click="() => this.clickService.increment(19)">
+                Increment
+            </button>
+        </div>
+    </t>
+
+</templates>


### PR DESCRIPTION
4. Move the state to a service
For now, our client action is just a hello world component. We want it to display our game state, but that state is currently only available in the systray item. So it means that we need to change the location of our state to make it available for all our components. This is a perfect use case for services.

Create a clicker_service.js file with the corresponding service.

This service should export a reactive value (the number of clicks) and a few functions to update it:

const state = reactive({ clicks: 0 });
...
return {
   state,
   increment(inc) {
      state.clicks += inc
   }
};
Access the state in both the systray item and the client action (don’t forget to useState it). Modify the systray item to remove its own local state and use it. Also, you can remove the +10 clicks button.

Display the state in the client action, and add a +10 clicks button in it.