### PR TITLE
TutorialOdooClikerGame/5_UseACustomHook

### DIFF
--- a/addons/awesome_clicker/static/src/clicker_hook.js
+++ b/addons/awesome_clicker/static/src/clicker_hook.js
@@ -1,0 +1,8 @@
+/** @odoo-module */
+
+import { useService } from "@web/core/utils/hooks"
+import { useState } from "@odoo/owl"
+
+export function useClicker() {
+    return useState(useService("awesome_clicker.clicker"))
+}

--- a/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.js
+++ b/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.js
@@ -3,6 +3,7 @@
 import { Component, useState, useExternalListener } from "@odoo/owl"
 import { registry } from "@web/core/registry"
 import { useService } from "@web/core/utils/hooks"
+import { useClicker } from "../clicker_hook"
 
 export class ClickerSystray extends Component {
     static template = "awesome_clicker.ClickerSystray"
@@ -11,7 +12,8 @@ export class ClickerSystray extends Component {
     setup() {
         // this.state = useState({ counter: 0 })
         this.action = useService("action")
-        this.clickService = useState(useService("awesome_clicker.clicker"))
+        // this.clickService = useState(useService("awesome_clicker.clicker"))
+        this.clicker = useClicker()
     }
 
     openClientAction() {

--- a/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.xml
+++ b/addons/awesome_clicker/static/src/clicker_systray_item/clicker_systray_item.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
     <t t-name="awesome_clicker.ClickerSystray">
         <div class="o_nav_entry">
-            Clicks: <t t-esc="clickService.state.clicks"/>
-            <button class="btn btn-secondary" t-on-click="() => this.clickService.increment(9)">
+            <span>Clicks: <t t-esc="this.clicker.state.clicks"/></span>
+            <button class="btn btn-secondary ms-1" t-on-click="() => this.clicker.increment(9)">
                 <i class="fa fa-lg fa-plus"></i>
             </button>
             <button class="btn btn-secondary" t-on-click="openClientAction">

--- a/addons/awesome_clicker/static/src/client_action/client_action.js
+++ b/addons/awesome_clicker/static/src/client_action/client_action.js
@@ -3,13 +3,15 @@
 import { Component, useState } from "@odoo/owl"
 import { registry } from "@web/core/registry"
 import { useService } from "@web/core/utils/hooks"
+import { useClicker } from "../clicker_hook";
 
 class ClickerClientAction extends Component {
     static template = "awesome_clicker.ClickerClientAction"
     static props = ['*']
 
     setup() {
-        this.clickService = useState(useService("awesome_clicker.clicker"))
+        // this.clickService = useState(useService("awesome_clicker.clicker"))
+        this.clicker = useClicker();
     }
 
 }

--- a/addons/awesome_clicker/static/src/client_action/client_action.xml
+++ b/addons/awesome_clicker/static/src/client_action/client_action.xml
@@ -2,8 +2,8 @@
 
     <t t-name="awesome_clicker.ClickerClientAction">
         <div class="ms-1 mt-1">
-            <span>Clicks: <t t-esc="clickService.state.clicks"/></span>
-            <button class="btn btn-primary ms-1" t-on-click="() => this.clickService.increment(19)">
+            <span>Clicks: <t t-esc="this.clicker.state.clicks"/></span>
+            <button class="btn btn-primary ms-1" t-on-click="() => this.clicker.increment(19)">
                 Increment
             </button>
         </div>


### PR DESCRIPTION
5. Use a custom hook
Right now, every part of the code that will need to use our clicker service will have to import useService and useState. Since it is quite common, let us use a custom hook. It is also useful to put more emphasis on the clicker part, and less emphasis on the service part.

Export a useClicker hook.

Update all current uses of the clicker service to the new hook:

this.clicker = useClicker();