### PR TITLE
TutorialOdooClikerGame/7_AddATooltipInClickValueComponent

### DIFF
--- a/addons/awesome_clicker/static/src/clicker_value/clicker_value.xml
+++ b/addons/awesome_clicker/static/src/clicker_value/clicker_value.xml
@@ -1,5 +1,5 @@
 <templates xml:space="preserve">
     <t t-name="awesome_clicker.ClickerValue">
-        <t t-esc="humanizedClicks"/>
+        <span t-att-data-tooltip="this.clicker.state.clicks" t-esc="humanizedClicks"/>
     </t>
 </templates>


### PR DESCRIPTION
7. Add a tooltip in ClickValue component
With the humanNumber function, we actually lost some precision on our interface. Let us display the real number as a tooltip.

Tooltip needs an html element. Change the ClickValue to wrap the value in a <span/> element

Add a dynamic data-tooltip attribute to display the exact value.